### PR TITLE
Ignore plays that happened before the item was added

### DIFF
--- a/MediaCleaner/ItemsAdapter.cs
+++ b/MediaCleaner/ItemsAdapter.cs
@@ -46,6 +46,13 @@ internal class ItemsAdapter
                 continue;
             }
 
+            if (userData.LastPlayedDate < item.DateCreated)
+            {
+                _logger.LogWarning("Ignoring \"{Name}\" ({Id}): played by \"{Username}\" at {LastPlayedDate}, but added at {DateCreated}",
+                    item.Name, item.Id, user.Username, userData.LastPlayedDate, item.DateCreated);
+                continue;
+            }
+
             result.Add(new ExpiredItem
             {
                 Item = item,


### PR DESCRIPTION
If a user has watched an item before it was added to Jellyfin, that play is ignored.

This is needed because the Trakt plugin sets the exact date of last play. In this scenario: a file is imported, it is marked as watched by Trakt, this plugin sees it as expired, and the file is immediately deleted.

My reasoning for this change is that while a file is in Jellyfin, it should stay there until someone actually watches it. This would also remove the need for the setting to mark items as unwatched on deletion, as future imports would simply ignore those plays.

Please note that I'm not at all familiar with C# or Jellyfin plugins, so double check my code. Also, this feature should probably be put behind a user setting, but I don't know how to do that. Feel free to make all the changes you deem necessary.

Closes #34.