### PR TITLE
Check creation date for unwatched items

### DIFF
--- a/MediaCleaner/ItemsAdapter.cs
+++ b/MediaCleaner/ItemsAdapter.cs
@@ -88,7 +88,7 @@ internal class ItemsAdapter
             var userData = _userDataManager.GetUserData(user, item);
 
             var isWatching = userData.PlaybackPositionTicks != 0;
-            if (userData.Played || isWatching)
+            if ((userData.Played && userData.LastPlayedDate >= item.DateCreated) || isWatching)
             {
                 _logger.LogTrace("\"{Name}\" ({Id}) was played by {Username}", item.Name, item.Id, user.Username);
                 continue;


### PR DESCRIPTION
Adds the same check performed in #36 to the unplayed items (added with #41).

In this way, if an item is not played or was played before being added to Jellyfin, it is considered as "not played by anyone".

Solves the case in which `alice` watched a movie before it was added, and `bob` did not watch it. Currently, the media cleaner would not consider it watched by anyone (since the only watch is older than the file), but also not unwatched by everyone because it marks it watched by `alice`. This makes the file undeletable by the plugin.

With my patch, the behavior is consistent between the two filters: both consider files newer than their plays as unwatched.