### PR TITLE
Fix MissingMethodException on Jellyfin 10.11.9+ (IUserManager.Users removed)

### DIFF
--- a/MediaCleaner/MediaCleaner.csproj
+++ b/MediaCleaner/MediaCleaner.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.3-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.3-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.9-*" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.9-*" />
     <PackageReference Include="System.Text.Json" Version="9.0.11" />
   </ItemGroup>
 

--- a/MediaCleaner/MediaCleanupTask.cs
+++ b/MediaCleaner/MediaCleanupTask.cs
@@ -76,21 +76,21 @@ namespace MediaCleaner
         {
             _logger.LogDebug("UsersPlayedMode: {Mode}", Configuration.UsersPlayedMode);
             _logger.LogDebug("UsersIgnorePlayed: {Users}",
-                 _userManager.Users
+                 _userManager.GetUsers()
                     .Where(x => Configuration.UsersIgnorePlayed.Contains(x.Id.ToString("N")))
                     .Select(x => $"{x.Username}={x.Id}")
             );
             _logger.LogDebug("UsersFavoritedMode: {Mode}", Configuration.UsersFavoritedMode);
             _logger.LogDebug("UsersIgnoreFavorited: {Users}",
-                 _userManager.Users
+                 _userManager.GetUsers()
                     .Where(x => Configuration.UsersIgnoreFavorited.Contains(x.Id.ToString("N")))
                     .Select(x => $"{x.Username}={x.Id}")
             );
 
-            var users = _userManager.Users
+            var users = _userManager.GetUsers()
                 .Where(x => FilterUsersList(Configuration.UsersIgnorePlayed, Configuration.UsersPlayedMode, x))
                 .ToList();
-            var usersWithFavorites = _userManager.Users
+            var usersWithFavorites = _userManager.GetUsers()
                 .Where(x => FilterUsersList(Configuration.UsersIgnoreFavorited, Configuration.UsersFavoritedMode, x))
                 .ToList();
 


### PR DESCRIPTION
Jellyfin removed the `IUserManager.Users` property in 10.11.x, which causes the
"Played media cleanup" task to crash at runtime with:

System.MissingMethodException: Method not found:
'IEnumerable<...User> IUserManager.get_Users()'

This replaces the four `_userManager.Users` references in MediaCleanupTask.cs
with `_userManager.GetUsers()`, which is the supported method on current Jellyfin.

Tested on Jellyfin 10.11.9 — cleanup task now runs and deletes items correctly.