### PR TITLE
fix: protect media being watched

### DIFF
--- a/MediaCleaner/Filtering/ExpiredFilter.cs
+++ b/MediaCleaner/Filtering/ExpiredFilter.cs
@@ -81,13 +81,21 @@ internal class ExpiredFilter : IExpiredItemFilter
 
     private bool IsAnyUserRollingWatched(List<ExpiredItemData> users)
     {
-        if (!users.Any(x => x.IsPlayed || x.IsWatching))
+        var watchingUsers = users.Where(x => x.IsWatching).ToList();
+        if (watchingUsers.Count > 0)
+        {
+            _logger.LogTrace("Currently being watched by \"{Usernames}\"", string.Join(", ", watchingUsers.Select(x => x.User.Username)));
+            return false;
+        }
+
+        var playedUsers = users.Where(x => x.IsPlayed).ToList();
+        if (playedUsers.Count == 0)
         {
             _logger.LogTrace("Not played by any user");
             return false;
         }
 
-        var user = users.OrderByDescending(x => x.LastPlayedDate).First();
+        var user = playedUsers.OrderByDescending(x => x.LastPlayedDate).First();
         var expirationTime = user.LastPlayedDate.AddDays(_keepFor);
 
         _logger.LogTrace("Latest played by \"{Username}\"", user.User.Username);


### PR DESCRIPTION
Fixes #58

## Root cause
`IsAnyUserRollingWatched` (used by `AnyUserRolling` keep mode) treated in-progress items (`IsWatching = true`, `IsPlayed = false`) the same as fully-played items. It would include them in the candidate set, then compute expiration from `LastPlayedDate` — which Jellyfin sets even for partial watches. So a partially-watched item with `KeepFor = 0` would get deleted immediately.

## Fix
1. Early-exit if any user has an active playback position (`IsWatching = true`) — protect the item unconditionally, matching the behaviour already present in `GetNotPlayedItems`.
2. Only consider fully-played users (`IsPlayed = true`) when computing the latest-played expiration, consistent with how `IsAnyUserWatched` and `IsAllUsersWatched` work.

## How the fix was tested
- Set `Keep played for X days` to `0`
- Set `Keep while not played by` to `Any user (latest playback)`
- Started watching the movie "Heads of State" and stopped partway through
- Manually ran `Played media cleanup` from `Admin` → `Scheduled Tasks`
- The movie was not deleted

### Other tests
The test scenario produced the following troubleshooting output:
```
[Deb] MediaCleanupTask: UsersPlayedMode: Ignore
[Deb] MediaCleanupTask: UsersIgnorePlayed:
[Deb] MediaCleanupTask: UsersFavoritedMode: Ignore
[Deb] MediaCleanupTask: UsersIgnoreFavorited:
[Deb] MediaCleanupTask: Adding tag filter with mode: Exclusion, tag: mediacleaner_keep
[Tra] JunkCollectors.MoviesJunkCollector: Collecting played items for 3 users started at 05/27/2026 23:25:07
[Deb] ItemsAdapter: "Heads of State" played by "Brian" (05/27/2026 23:15:46)
[Deb] JunkCollectors.MoviesJunkCollector: Filters order: Expired, Favorites, Locations, Tag
[Deb] JunkCollectors.MoviesJunkCollector: 1 items before filtering
[Tra] Filtering.ExpiredFilter: Filtering item "Heads of State"
[Tra] Filtering.ExpiredFilter: Currently being watched by "Brian"
[Tra] JunkCollectors.MoviesJunkCollector: "Heads of State" filtered by Expired
[Deb] JunkCollectors.MoviesJunkCollector: 0 items after filtering
[Tra] JunkCollectors.MoviesJunkCollector: Collecting finished at 05/27/2026 23:25:07
```

Please note the "Currently being watched by..." message and that the filter produced 0 items. Previously this movie would have been marked for deletion.

## Notes
This depends on the fix applied on #102 to restore the plugin's general functionality (it is completely broken as of now).