### PR TITLE
feat: add KeepLatestWatched series exception for episodes (v3.3.0)

### DIFF
--- a/Directory.JellyfinProfiles.props
+++ b/Directory.JellyfinProfiles.props
@@ -2,7 +2,7 @@
   <!-- Generated from eng/jellyfin-profiles.json. Run eng/generate-jellyfin-props.ps1 to update. -->
 
   <PropertyGroup>
-    <PluginBaseVersion Condition="'$(PluginBaseVersion)' == ''">3.2.0</PluginBaseVersion>
+    <PluginBaseVersion Condition="'$(PluginBaseVersion)' == ''">3.3.0</PluginBaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(JellyfinBuildProfile)' == '' And '$(JellyfinProfile)' == '10.10.7'">

--- a/MediaCleaner.Core/CleanupTypes.cs
+++ b/MediaCleaner.Core/CleanupTypes.cs
@@ -36,6 +36,7 @@ public enum SeriesKeepKind
     None,
     First,
     Last,
+    LatestWatched,
 }
 
 public enum LocationsListMode

--- a/MediaCleaner.Core/SeriesPolicyEvaluator.cs
+++ b/MediaCleaner.Core/SeriesPolicyEvaluator.cs
@@ -63,9 +63,19 @@ internal static class SeriesPolicyEvaluator
             yield break;
         }
 
-        if (rule.Filters.KeepSeriesKind is not SeriesKeepKind.First and not SeriesKeepKind.Last)
+        if (rule.Filters.KeepSeriesKind is not SeriesKeepKind.First and not SeriesKeepKind.Last and not SeriesKeepKind.LatestWatched)
         {
             throw new NotSupportedException($"Unsupported series keep kind: {rule.Filters.KeepSeriesKind}");
+        }
+
+        if (rule.Filters.KeepSeriesKind == SeriesKeepKind.LatestWatched)
+        {
+            foreach (var item in KeepLatestWatchedEpisodes(items, rule, auditEntries))
+            {
+                yield return item;
+            }
+
+            yield break;
         }
 
         var boundaryName = rule.Filters.KeepSeriesKind == SeriesKeepKind.First ? "first" : "latest";
@@ -126,6 +136,73 @@ internal static class SeriesPolicyEvaluator
                     CleanupAuditStage.SeriesPolicy,
                     CleanupAuditOutcome.Skipped,
                     $"series policy keeps the {boundaryName} episode '{boundaryId}' in series '{group.Key}'; that episode did not match this rule");
+            }
+        }
+    }
+
+    private static IEnumerable<CandidateItem> KeepLatestWatchedEpisodes(
+        IEnumerable<CandidateItem> items,
+        CleanupRule rule,
+        List<CleanupAuditEntry> auditEntries)
+    {
+        foreach (var group in items.GroupBy(x => x.Item.SeriesId ?? x.Item.Id))
+        {
+            var groupItems = group.ToList();
+
+            // Prefer an episode that is actively being watched (credits rolling).
+            // IsWatching is true when PlaybackPositionTicks != 0, which stays set
+            // while the player is open even after Jellyfin auto-marks it as played.
+            var watchingCandidate = groupItems
+                .Where(x => x.Playback.Any(p => p.IsWatching))
+                .OrderByDescending(x => x.Playback
+                    .Where(p => p.IsWatching)
+                    .Max(p => p.LastPlayedDate ?? DateTime.MinValue))
+                .FirstOrDefault();
+
+            // Fall back to the episode most recently played by any matching user.
+            var latestPlayedCandidate = watchingCandidate ?? groupItems
+                .Where(x => x.Playback.Any(p => p.LastPlayedDate.HasValue))
+                .OrderByDescending(x => x.Playback
+                    .Max(p => p.LastPlayedDate ?? DateTime.MinValue))
+                .FirstOrDefault();
+
+            if (latestPlayedCandidate is null)
+            {
+                // No playback data in any candidate — cannot determine the latest watched episode;
+                // block deletion of all candidates in this series to be safe.
+                foreach (var item in groupItems)
+                {
+                    CleanupAudit.AddItem(
+                        auditEntries,
+                        item.Item,
+                        rule,
+                        CleanupAuditStage.SeriesPolicy,
+                        CleanupAuditOutcome.Blocked,
+                        $"delete blocked by series policy because the latest watched episode in series '{group.Key}' could not be determined (no playback data)");
+                }
+
+                continue;
+            }
+
+            foreach (var item in groupItems)
+            {
+                if (string.Equals(item.Item.Id, latestPlayedCandidate.Item.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    var reason = watchingCandidate is not null
+                        ? $"rejected by series policy because episode '{item.Item.Id}' is currently being watched (credits may be rolling) in series '{group.Key}'"
+                        : $"rejected by series policy because episode '{item.Item.Id}' is the latest watched episode in series '{group.Key}'";
+
+                    CleanupAudit.AddItem(
+                        auditEntries,
+                        item.Item,
+                        rule,
+                        CleanupAuditStage.SeriesPolicy,
+                        CleanupAuditOutcome.Rejected,
+                        reason);
+                    continue;
+                }
+
+                yield return item;
             }
         }
     }

--- a/MediaCleaner/Configuration/PluginConfiguration.cs
+++ b/MediaCleaner/Configuration/PluginConfiguration.cs
@@ -36,6 +36,7 @@ namespace MediaCleaner.Configuration
         None,
         First,
         Last,
+        LatestWatched,
     }
 
     public enum LocationsListMode

--- a/MediaCleaner/PluginConfigurationMapper.cs
+++ b/MediaCleaner/PluginConfigurationMapper.cs
@@ -344,6 +344,7 @@ internal static class PluginConfigurationMapper
         ConfigSeriesKeepKind.None => CoreSeriesKeepKind.None,
         ConfigSeriesKeepKind.First => CoreSeriesKeepKind.First,
         ConfigSeriesKeepKind.Last => CoreSeriesKeepKind.Last,
+        ConfigSeriesKeepKind.LatestWatched => CoreSeriesKeepKind.LatestWatched,
         _ => throw new NotSupportedException($"Unsupported series keep kind: {value}"),
     };
 }

--- a/MediaCleaner/Web/general.js
+++ b/MediaCleaner/Web/general.js
@@ -858,7 +858,7 @@ function renderDeletionBehavior(rule) {
     const episodeControls = isEpisodeOnly(rule)
         ? selectHtml('DeleteEpisodes', 'Episode deletion scope', rule.Filters.DeleteEpisodes, ['Episode', 'Season', 'Series', 'SeriesEnded'])
             + (['Episode', 'Season'].includes(rule.Filters.DeleteEpisodes)
-                ? selectHtml('KeepSeriesKind', rule.Filters.DeleteEpisodes === 'Season' ? 'Season exception' : 'Episode exception', rule.Filters.KeepSeriesKind, ['None', 'First', 'Last'])
+                ? selectHtml('KeepSeriesKind', rule.Filters.DeleteEpisodes === 'Season' ? 'Season exception' : 'Episode exception', rule.Filters.KeepSeriesKind, ['None', 'First', 'Last', 'LatestWatched'])
                     + `<div class="fieldDescription">${exceptionDescription}</div>`
                 : '')
         : ''
@@ -971,6 +971,7 @@ function triggerDaysLabel(kind) {
 function episodeScopeWithPreservedItem(summary, filters, itemKind) {
     if (filters.KeepSeriesKind === 'First') return `${summary}, excluding the first ${itemKind} in the series, whether or not it matches this rule`
     if (filters.KeepSeriesKind === 'Last') return `${summary}, excluding the latest ${itemKind} in the series, whether or not it matches this rule`
+    if (filters.KeepSeriesKind === 'LatestWatched') return `${summary}, excluding the most recently watched ${itemKind} in the series (including episodes currently playing or rolling credits)`
     return summary
 }
 
@@ -1154,6 +1155,10 @@ function episodeScopeSentence(filters) {
         return 'Delete matching episodes individually, except the latest episode in the series, whether or not it matches this rule'
     }
 
+    if (filters.KeepSeriesKind === 'LatestWatched') {
+        return 'Delete matching episodes individually, except the most recently watched episode in the series (including episodes currently playing or with credits rolling)'
+    }
+
     return ''
 }
 
@@ -1176,6 +1181,10 @@ function episodeScopeClause(filters) {
 
     if (filters.KeepSeriesKind === 'Last') {
         return 'excluding the latest episode in each series, whether or not it matches this rule'
+    }
+
+    if (filters.KeepSeriesKind === 'LatestWatched') {
+        return 'excluding the most recently watched episode in each series (including episodes currently playing or with credits rolling)'
     }
 
     return ''

--- a/README.md
+++ b/README.md
@@ -1,124 +1,28 @@
 
-# Media Cleaner for Jellyfin
+## Overview
 
-Automatically delete media according to configurable rules. Works with any media types.
+Adds a new SeriesKeepKind option 'LatestWatched' that protects the most
+recently-watched episode in a series from deletion, even when it matches
+an active cleanup rule. This is designed to handle two real-world cases:
 
-## Installation
+  1. The user has finished watching an episode and the cleanup rule would
+     ordinarily delete it immediately (e.g. 'delete played episodes after
+     0 days'). KeepLatestWatched ensures the last episode they watched is
+     always retained.
 
-Add repository with my plugins from [jellyfin-plugin-repo](https://github.com/shemanaev/jellyfin-plugin-repo).
+  2. The user stopped playback while the credits were still rolling.
+     Jellyfin marks the episode as 'played' when the user reaches the
+     credit point, but keeps PlaybackPositionTicks non-zero until the
+     playback session fully closes. This plugin maps that to IsWatching=true.
+     The new exception explicitly protects any episode in that state, so it
+     will never be deleted mid-session.
 
-## Configuration
+## How KeepLatestWatched differs from the existing 'Last' option
 
-Media Cleaner is configured via the rules.
+- 'Last' keeps the final episode in series index order (e.g. S02E10 of a
+  10-episode season), regardless of whether it was ever watched.
 
-### Rules
-
-Rules are split into cleanup rules and protection rules.
-
-* Cleanup rules delete media after it matches their trigger and filters.
-* Protection rules never delete media. They exclude matching media from deletion by any cleanup rule.
-* Cleanup rules are additive: if several cleanup rules match the same item, the item is planned once.
-* Protection rules win regardless of rule order. A protected item suppresses direct deletion, and protected children block season or series deletion cascades.
-
-Each rule has:
-
-* a trigger: played before cutoff, not played since added, or age since added regardless of playback;
-* a media scope: one media type or all media;
-* optional filters for playback users, favorite state, favorite users, library locations and tags;
-* an action: delete or protect.
-
-For episode cleanup rules, the deletion scope controls whether Media Cleaner deletes matching episodes individually, complete seasons, complete series, or complete ended series. Episode and season scopes can keep the first or latest item in the entire series as an exception, even when that item does not match the rule. Cleanup is blocked when the configured exception cannot be identified safely.
-
-Played cleanup can require playback by at least one user, the most recent play by any user, or every user. Not-played cleanup can ignore older playback history so old watches do not keep new imports forever.
-
-Tag filters only affect rule matching. Changing a tag in a rule does not rename tags already stored on Jellyfin items; use **Advanced** for library tag maintenance.
-
-### Advanced
-
-The **Advanced** tab contains tools and safety switches that should not be hidden inside ordinary rules:
-
-* **Count playback before Date Added** changes how played and not-played rules handle Jellyfin items whose `LastPlayedDate` is earlier than `DateCreated` / "*Date Added*".
-* **Library tag maintenance** previews and then renames a tag on matching Jellyfin library items. It does not update rule definitions automatically.
-
-### Troubleshooting
-
-The **Troubleshooting** tab runs a dry-run cleanup report and opens it in a formatted viewer. It shows the plugin configuration, final delete decisions, planned deletion operations, audit entries, outcome summaries, rule-level decisions and item-level decisions. Use it before enabling risky rules or when a rule does not match the items you expected.
-
-### When deletion happens
-
-Saving Media Cleaner settings does not delete anything immediately. Actual deletion happens only when Jellyfin runs the **Media Cleaner cleanup** scheduled task, or when an admin starts that scheduled task manually.
-
-Its default trigger is once per day, but the exact run time, custom triggers, manual runs and disabled state are controlled by Jellyfin's **Scheduled Tasks** page, not by Media Cleaner's rule editor.
-
-On each task run, Media Cleaner loads the current rules, scans the Jellyfin library, builds a cleanup plan, applies protection rules and cascade safety checks, then executes the planned delete operations. If no cleanup rule matches, no item is deleted.
-
-The **Troubleshooting** report uses the same planning path in dry-run mode. It shows what would be deleted by a real scheduled-task run, but the report itself does not delete or modify media.
-
-### Jellyfin Date Added behavior
-
-Jellyfin's "*Date added behavior for new content*" setting affects rules that use "*played*" or "*not played*" state, because Media Cleaner compares Jellyfin's `DateCreated` / "*Date Added*" value with the user's `LastPlayedDate`.
-
-There is no single correct setting for every Radarr/Sonarr/download-client setup:
-
-  1. Leave it at the default value ("*Use file creation date*")
-      - this can preserve the original media age when Radarr/Sonarr upgrades a file after it was watched;
-      - however, recently downloaded files can be deleted on the first cleanup run if your software sets an old filesystem creation date from metadata or from the source file.
-  2. Change it to "*Use date scanned into the library*"
-      - this helps prevent newly downloaded or re-downloaded media from being deleted immediately based on old playback history;
-      - however, if Radarr/Sonarr upgrades a file after it was watched, Jellyfin can set "*Date Added*" later than `LastPlayedDate`. Media Cleaner treats this as ambiguous by default: played cleanup will not use that playback, and not-played cleanup will not delete the item solely because of the date conflict.
-
-Changing Jellyfin's setting does not usually rewrite existing item dates.
-
-If a rule behaves unexpectedly, run Media Cleaner's troubleshooting report and look for entries where `LastPlayedDate` is before Jellyfin "*Date Added*". Those items usually need Jellyfin metadata correction, a different Jellyfin date-added mode for future imports, or an external date-preservation workaround.
-
-If a rule is configured to ignore older playback history, playback before "*Date Added*" is only treated as ambiguous while it is still inside that history window.
-
-Media Cleaner's advanced "*Count playback before Date Added*" setting changes this safety behavior. It counts playback even when `LastPlayedDate` is earlier than "*Date Added*". This can help with upgraded or re-imported media where Jellyfin reset the added date. Enable it only if you accept the tradeoff: newly re-downloaded media can be deleted based on old watch history.
-
-### Played items without a played date
-
-Media Cleaner relies on Jellyfin playback dates when evaluating rules based on played media. Some Jellyfin clients or imported playback data can mark an item as played without setting a `LastPlayedDate`.
-
-When this happens, Media Cleaner cannot know when the item was actually watched. The plugin intentionally does not invent a playback date, because doing so could make cleanup decisions unsafe or misleading.
-
-If played items are not deleted as expected, check the item/user playback data in Jellyfin first. Fix the source client, import process, or use an external repair/sync tool that writes correct Jellyfin playback dates before relying on played-date cleanup rules. One reported workaround is [jellyfin-watch-updater](https://github.com/Simon-Eklundh/jellyfin-watch-updater), which can set `LastPlayedDate` by marking items as played through Jellyfin's API.
-
-## Debugging
-
-Define `JellyfinHome` environment variable pointing to Jellyfin distribution to be able to run debug configuration.
-
-## Jellyfin ABI support
-
-Builds are selected through `JellyfinProfile`. Server profiles are mapped to ABI build profiles in `eng/jellyfin-profiles.json`, so compatible server versions share release artifacts. `Directory.JellyfinProfiles.props` is generated from that JSON and imported by MSBuild.
-
-```powershell
-dotnet build MediaCleaner.sln -p:JellyfinProfile=10.10.7
-dotnet build MediaCleaner.sln -p:JellyfinProfile=10.11.0
-dotnet build MediaCleaner.sln -p:JellyfinProfile=10.11.3
-dotnet build MediaCleaner.sln -p:JellyfinProfile=10.11.11
-```
-
-Use the packaging helper to generate ABI build artifacts and `build.yaml` files under `artifacts/<build-profile>`:
-
-```powershell
-.\eng\build-plugin.ps1 -Configuration Release
-```
-
-When Jellyfin changes ABI, add or update a build profile in `eng/jellyfin-profiles.json` with the package version, target ABI, target framework, `versionPatchOffset` and any compile constants needed by `MediaCleaner/Compatibility/JellyfinCompatibility.cs`. Map server versions to build profiles in the same file, then run `.\eng\generate-jellyfin-props.ps1`. Keep direct Jellyfin API changes in the compatibility layer first; the task, filters and controllers should call that layer instead of branching on server versions directly.
-
-To bump the plugin release version, update `baseVersion` and regenerate MSBuild profile properties:
-
-```powershell
-.\eng\bump-version.ps1
-.\eng\bump-version.ps1 -Version 2.25.0
-```
-
-## Contributing
-
-### Generative AI Policy
-
-You're welcome to use "generative AI" coding tools when contributing, however:
-
-* You (the human contributor) should always be reading and validating new code before submitting it to us for review.
-* You (the human contributor) should be prepared to communicate with us personally during the PR review process. Copy-pasting to and from a chatbot is unacceptable, unless you're only using it for translation to and from English. If you don't know something then please tell us the prompt you would use for the question, instead of pasting the chatbot's answer - because chatbots are not always correct!
-* Please do not allow "AI Agents" to submit Pull Requests by themselves. Human maintainers will make time to review your code, and we expect a human contributor to make time as well.
+- 'LatestWatched' keeps the episode most recently interacted with by any
+  matching user, determined by LastPlayedDate. If any candidate episode is
+  currently IsWatching (credits rolling / session open), that episode takes
+  priority over the LastPlayedDate comparison.


### PR DESCRIPTION
## Overview

Adds a new SeriesKeepKind option 'LatestWatched' that protects the most
recently-watched episode in a series from deletion, even when it matches
an active cleanup rule. This is designed to handle two real-world cases:

  1. The user has finished watching an episode and the cleanup rule would
     ordinarily delete it immediately (e.g. 'delete played episodes after
     0 days'). KeepLatestWatched ensures the last episode they watched is
     always retained.

  2. The user stopped playback while the credits were still rolling.
     Jellyfin marks the episode as 'played' when the user reaches the
     credit point, but keeps PlaybackPositionTicks non-zero until the
     playback session fully closes. This plugin maps that to IsWatching=true.
     The new exception explicitly protects any episode in that state, so it
     will never be deleted mid-session.

## How KeepLatestWatched differs from the existing 'Last' option

- 'Last' keeps the final episode in series index order (e.g. S02E10 of a
  10-episode season), regardless of whether it was ever watched.

- 'LatestWatched' keeps the episode most recently interacted with by any
  matching user, determined by LastPlayedDate. If any candidate episode is
  currently IsWatching (credits rolling / session open), that episode takes
  priority over the LastPlayedDate comparison.

## Changes

### MediaCleaner.Core/CleanupTypes.cs
- Added 'LatestWatched' to the SeriesKeepKind enum.

### MediaCleaner.Core/SeriesPolicyEvaluator.cs
- Updated the KeepEpisodes() guard to allow SeriesKeepKind.LatestWatched
  alongside the existing First and Last values.
- Added early dispatch: when KeepSeriesKind == LatestWatched the method
  routes to KeepLatestWatchedEpisodes() and returns, keeping the two code
  paths cleanly separated.
- Implemented new private method KeepLatestWatchedEpisodes():
    * Groups all candidate episodes by series ID (same pattern as the
      existing First/Last logic).
    * Step 1 — Credits/active watch priority: finds any candidate where
      Playback contains an entry with IsWatching=true. If multiple
      candidates are watching, the one with the most recent
      LastPlayedDate among the watching entries wins.
    * Step 2 — Latest-played fallback: if no candidate is currently
      watching, finds the candidate with the highest LastPlayedDate
      across all matching users' playback entries.
    * Safe default: if no playback data exists for any candidate in the
      group (e.g. the episode was matched by an AddedAge rule with no
      user filter), deletion is blocked for the whole series group with
      a clear audit message rather than silently deleting.
    * Audit entries are written for every outcome (Rejected / Blocked)
      so the Troubleshooting page shows exactly why an episode was kept.

### MediaCleaner/Configuration/PluginConfiguration.cs
- Added 'LatestWatched' to the plugin-layer SeriesKeepKind enum so the
  value can be persisted in the XML configuration file and round-tripped
  correctly across Jellyfin restarts.

### MediaCleaner/PluginConfigurationMapper.cs
- Added the mapping ConfigSeriesKeepKind.LatestWatched ->
  CoreSeriesKeepKind.LatestWatched in the Map() switch expression.

### MediaCleaner/Web/general.js
- Added 'LatestWatched' to the KeepSeriesKind select dropdown (appears
  alongside None, First, Last) for both the Episode and Season scopes.
- Updated episodeScopeWithPreservedItem() to generate the correct human-
  readable description when LatestWatched is selected with Season scope.
- Updated episodeScopeSentence() (used in rule card summaries) with a
  LatestWatched branch that mentions credits-rolling behaviour.
- Updated episodeScopeClause() (used in auto-generated rule label text)
  with an equivalent LatestWatched branch.

### Directory.JellyfinProfiles.props
- Bumped PluginBaseVersion from 3.2.0 to 3.3.0 to reflect the new
  feature. All three Jellyfin build profiles (10.10.7, 10.11.0, 10.11.9)
  inherit this base version and retain their existing patch offsets.